### PR TITLE
add Orange Pi 5 Plus support

### DIFF
--- a/target/linux/rockchip/dts/rk3588/rk3588-orangepi-5-plus-camera1.dtsi
+++ b/target/linux/rockchip/dts/rk3588/rk3588-orangepi-5-plus-camera1.dtsi
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Copyright (c) 2021 Rockchip Electronics Co., Ltd.
+ *
+ */
+
+&mipi_dcphy0 {
+    status = "okay";
+};
+
+&csi2_dphy0_hw {
+	status = "disabled";
+};
+
+&csi2_dphy0 {
+	status = "disabled";
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		port@0 {
+			reg = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			mipi_in_ucam0: endpoint@0 {
+				reg = <0>;
+				remote-endpoint = <&ov13850_out2>;
+				data-lanes = <1 2>;
+			};
+
+			mipi_in_ucam1: endpoint@1 {
+				reg = <1>;
+				remote-endpoint = <&ov13855_out2>;
+				data-lanes = <1 2>;
+			};
+		};
+		port@1 {
+		        reg = <1>;
+		        #address-cells = <1>;
+		        #size-cells = <0>;
+		        csidphy0_out: endpoint@0 {
+		                reg = <0>;
+		                remote-endpoint = <&mipi2_csi2_input>;
+		        };
+		};
+	};
+};
+
+&i2c3 {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c3m0_xfer>;
+
+	vm149c_p1: vm149c-p1@c {
+		compatible = "silicon touch,vm149c";
+		status = "disabled";
+		reg = <0x0c>;
+		rockchip,camera-module-index = <1>;
+		rockchip,camera-module-facing = "back";
+	};
+
+	ov13850_1: ov13850-1@10 {
+		compatible = "ovti,ov13850";
+		status = "disabled";
+		reg = <0x10>;
+		clocks = <&cru CLK_MIPI_CAMARAOUT_M3>;
+		clock-names = "xvclk";
+		pinctrl-names = "default";
+		pinctrl-0 = <&mipim1_camera3_clk>;
+		reset-gpios = <&gpio1 RK_PC4 GPIO_ACTIVE_HIGH>;
+		pwdn-gpios = <&gpio1 RK_PD5 GPIO_ACTIVE_HIGH>;
+		rockchip,camera-module-index = <0>;
+		rockchip,camera-module-facing = "back";
+		rockchip,camera-module-name = "CMK-CT0116";
+		rockchip,camera-module-lens-name = "default";
+		lens-focus = <&vm149c_p1>;
+		port {
+			ov13850_out2: endpoint {
+				remote-endpoint = <&mipi_in_ucam0>;
+				data-lanes = <1 2>;
+			};
+		};
+	};
+
+	dw9714_p1: dw9714-p1@c {
+		compatible = "dongwoon,dw9714";
+		status = "disabled";
+		reg = <0x0c>;
+		rockchip,camera-module-index = <0>;
+		rockchip,vcm-start-current = <10>;
+		rockchip,vcm-rated-current = <85>;
+		rockchip,vcm-step-mode = <5>;
+		rockchip,camera-module-facing = "back";
+	};
+
+	ov13855_1: ov13855-1@36 {
+		compatible = "ovti,ov13855";
+		status = "disabled";
+		reg = <0x36>;
+		clocks = <&cru CLK_MIPI_CAMARAOUT_M3>;
+		clock-names = "xvclk";
+		pinctrl-names = "default";
+		pinctrl-0 = <&mipim1_camera3_clk>;
+		reset-gpios = <&gpio1 RK_PC4 GPIO_ACTIVE_HIGH>;
+		pwdn-gpios = <&gpio1 RK_PD5 GPIO_ACTIVE_HIGH>;
+		rockchip,camera-module-index = <0>;
+		rockchip,camera-module-facing = "back";
+		rockchip,camera-module-name = "CMK-OT2016-FV1";
+		rockchip,camera-module-lens-name = "default";
+		lens-focus = <&dw9714_p1>;
+		port {
+			ov13855_out2: endpoint {
+				remote-endpoint = <&mipi_in_ucam1>;
+				data-lanes = <1 2>;
+			};
+		};
+	};
+};
+
+&mipi2_csi2 {
+	status = "disabled";
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		port@0 {
+			reg = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			mipi2_csi2_input: endpoint@1 {
+				reg = <1>;
+				remote-endpoint = <&csidphy0_out>;
+			};
+		};
+		port@1 {
+			reg = <1>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			mipi2_csi2_output: endpoint@0 {
+				reg = <0>;
+				remote-endpoint = <&cif_mipi_in2>;
+			};
+		};
+	};
+};
+
+&rkcif {
+    status = "okay";
+};
+
+&rkcif_mmu {
+    status = "okay";
+};
+
+&rkcif_mipi_lvds2 {
+	status = "disabled";
+	port {
+		cif_mipi_in2: endpoint {
+			remote-endpoint = <&mipi2_csi2_output>;
+		};
+	};
+};
+
+&rkcif_mipi_lvds2_sditf {
+	status = "disabled";
+	port {
+		mipi2_lvds_sditf: endpoint {
+			remote-endpoint = <&isp0_vir1>;
+		};
+	};
+};
+
+&rkisp0 {
+    status = "okay";
+};
+
+&isp0_mmu {
+    status = "okay";
+};
+
+&rkisp0_vir1 {
+	status = "disabled";
+	port {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		isp0_vir1: endpoint@0 {
+			reg = <0>;
+			remote-endpoint = <&mipi2_lvds_sditf>;
+		};
+	};
+};

--- a/target/linux/rockchip/dts/rk3588/rk3588-orangepi-5-plus.dts
+++ b/target/linux/rockchip/dts/rk3588/rk3588-orangepi-5-plus.dts
@@ -861,14 +861,18 @@
 
 //phy2
 &pcie2x1l1 {
+	phys = <&pcie30phy>;
     reset-gpios = <&gpio3 RK_PB3 GPIO_ACTIVE_HIGH>;
+    prsnt-gpios = <&gpio3 RK_PB3 GPIO_ACTIVE_HIGH>;
     vpcie3v3-supply = <&vcc3v3_pcie_eth>;
     status = "okay";
 };
 
 //phy0
 &pcie2x1l2 {
+    phys = <&combphy2_psu PHY_TYPE_PCIE>;
     reset-gpios = <&gpio4 RK_PA2 GPIO_ACTIVE_HIGH>;
+    prsnt-gpios = <&gpio4 RK_PA2 GPIO_ACTIVE_HIGH>;
     vpcie3v3-supply = <&vcc3v3_pcie_eth>;
     status = "okay";
 };

--- a/target/linux/rockchip/dts/rk3588/rk3588-orangepi-5-plus.dts
+++ b/target/linux/rockchip/dts/rk3588/rk3588-orangepi-5-plus.dts
@@ -861,7 +861,6 @@
 
 //phy2
 &pcie2x1l1 {
-	phys = <&pcie30phy>;
     reset-gpios = <&gpio3 RK_PB3 GPIO_ACTIVE_HIGH>;
     prsnt-gpios = <&gpio3 RK_PB3 GPIO_ACTIVE_HIGH>;
     vpcie3v3-supply = <&vcc3v3_pcie_eth>;
@@ -870,7 +869,6 @@
 
 //phy0
 &pcie2x1l2 {
-    phys = <&combphy2_psu PHY_TYPE_PCIE>;
     reset-gpios = <&gpio4 RK_PA2 GPIO_ACTIVE_HIGH>;
     prsnt-gpios = <&gpio4 RK_PA2 GPIO_ACTIVE_HIGH>;
     vpcie3v3-supply = <&vcc3v3_pcie_eth>;
@@ -878,6 +876,7 @@
 };
 
 &pcie30phy {
+    rockchip,pcie30-phymode = <PHY_MODE_PCIE_AGGREGATION>;
     status = "okay";
 };
 

--- a/target/linux/rockchip/dts/rk3588/rk3588-orangepi-5-plus.dts
+++ b/target/linux/rockchip/dts/rk3588/rk3588-orangepi-5-plus.dts
@@ -1,0 +1,1340 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Copyright (c) 2021 Rockchip Electronics Co., Ltd.
+ *
+ */
+
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/pwm/pwm.h>
+#include <dt-bindings/pinctrl/rockchip.h>
+#include <dt-bindings/input/rk-input.h>
+#include <dt-bindings/display/drm_mipi_dsi.h>
+#include <dt-bindings/display/rockchip_vop.h>
+#include <dt-bindings/sensor-dev.h>
+#include "dt-bindings/usb/pd.h"
+#include "rk3588.dtsi"
+#include "rk3588-rk806-single.dtsi"
+#include "rk3588-linux.dtsi"
+#include "rk3588-orangepi-5-plus-camera1.dtsi"
+
+/ {
+	model = "Xunlong Orange Pi 5 Plus";
+	compatible = "xunlong,orangepi-5-plus", "rockchip,rk3588";
+
+	/delete-node/ chosen;
+
+	 adc_keys: adc-keys {
+		compatible = "adc-keys";
+		io-channels = <&saradc 1>;
+		io-channel-names = "buttons";
+		keyup-threshold-microvolt = <1800000>;
+		poll-interval = <100>;
+
+		vol-up-key {
+			label = "volume up";
+			linux,code = <KEY_VOLUMEUP>;
+			press-threshold-microvolt = <17000>;
+		};
+
+		vol-down-key {
+			label = "volume down";
+			linux,code = <KEY_VOLUMEDOWN>;
+			press-threshold-microvolt = <417000>;
+		};
+
+		menu-key {
+			label = "menu";
+			linux,code = <KEY_MENU>;
+			press-threshold-microvolt = <890000>;
+		};
+
+		back-key {
+			label = "back";
+			linux,code = <KEY_BACK>;
+			press-threshold-microvolt = <1235000>;
+		};
+	};
+
+	dp0_sound: dp0-sound {
+		status = "okay";
+		compatible = "rockchip,hdmi";
+		rockchip,card-name = "rockchip-dp0";
+		rockchip,mclk-fs = <512>;
+		rockchip,cpu = <&spdif_tx2>;
+		rockchip,codec = <&dp0 1>;
+		rockchip,jack-det;
+	};
+
+	fan: pwm-fan {
+		compatible = "pwm-fan";
+		#cooling-cells = <2>;
+		pwms = <&pwm3 0 50000 0>;
+		cooling-levels = <0 50 100 150 200 255>;
+		rockchip,temp-trips = <
+			50000   1
+			55000   2
+			60000   3
+			65000   4
+			70000   5
+		>;
+
+		status = "okay";
+	};
+
+	hdmi0_sound: hdmi0-sound {
+		status = "okay";
+		compatible = "rockchip,hdmi";
+		rockchip,mclk-fs = <128>;
+		rockchip,card-name = "rockchip-hdmi0";
+		rockchip,cpu = <&i2s5_8ch>;
+		rockchip,codec = <&hdmi0>;
+		rockchip,jack-det;
+	};
+
+	hdmi1_sound: hdmi1-sound {
+		status = "okay";
+		compatible = "rockchip,hdmi";
+		rockchip,mclk-fs = <128>;
+		rockchip,card-name = "rockchip-hdmi1";
+		rockchip,cpu = <&i2s6_8ch>;
+		rockchip,codec = <&hdmi1>;
+		rockchip,jack-det;
+	};
+
+	hdmiin-sound {
+		compatible = "rockchip,hdmi";
+		rockchip,mclk-fs = <128>;
+		rockchip,format = "i2s";
+		rockchip,bitclock-master = <&hdmirx_ctrler>;
+		rockchip,frame-master = <&hdmirx_ctrler>;
+		rockchip,card-name = "rockchip-hdmiin";
+		rockchip,cpu = <&i2s7_8ch>;
+		rockchip,codec = <&hdmirx_ctrler 0>;
+		rockchip,jack-det;
+	};
+
+	es8388_sound: es8388-sound {
+		status = "okay";
+		compatible = "rockchip,multicodecs-card";
+		rockchip,card-name = "rockchip-es8388";
+		hp-det-gpio = <&gpio1 RK_PD3 GPIO_ACTIVE_HIGH>;
+		io-channels = <&saradc 3>;
+		io-channel-names = "adc-detect";
+		keyup-threshold-microvolt = <1800000>;
+		poll-interval = <100>;
+		spk-con-gpio = <&gpio3 RK_PC0 GPIO_ACTIVE_HIGH>;
+		hp-con-gpio = <&gpio3 RK_PA7 GPIO_ACTIVE_HIGH>;
+		rockchip,format = "i2s";
+		rockchip,mclk-fs = <256>;
+		rockchip,cpu = <&i2s0_8ch>;
+		rockchip,codec = <&es8388>;
+		rockchip,audio-routing =
+			"Headphone", "LOUT1",
+			"Headphone", "ROUT1",
+			"Speaker", "LOUT2",
+			"Speaker", "ROUT2",
+			"Headphone", "Headphone Power",
+			"Headphone", "Headphone Power",
+			"Speaker", "Speaker Power",
+			"Speaker", "Speaker Power",
+			"LINPUT1", "Main Mic",
+			"LINPUT2", "Main Mic",
+			"RINPUT1", "Headset Mic",
+			"RINPUT2", "Headset Mic";
+		pinctrl-names = "default";
+		pinctrl-0 = <&hp_det>;
+		
+        play-pause-key {
+			label = "playpause";
+			linux,code = <KEY_PLAYPAUSE>;
+			press-threshold-microvolt = <2000>;
+		};
+	};
+
+	rk_headset: rk-headset {
+		status = "disabled";
+		compatible = "rockchip_headset";
+		headset_gpio = <&gpio1 RK_PD3 GPIO_ACTIVE_HIGH>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&hp_det>;
+		io-channels = <&saradc 3>;
+	 };
+
+	leds: gpio-leds {
+		compatible = "gpio-leds";
+		pinctrl-names = "default";
+		pinctrl-0 =<&leds_rgb>;
+		status = "okay";
+
+		blue_led@1 {
+			gpios = <&gpio3 RK_PA6 GPIO_ACTIVE_HIGH>;
+			label = "blue_led";
+			linux,default-trigger = "heartbeat";
+			linux,default-trigger-delay-ms = <0>;
+		};
+
+		green_led@2 {
+			gpios = <&gpio3 RK_PB1 GPIO_ACTIVE_HIGH>;
+			label = "green_led";
+			linux,default-trigger = "heartbeat";
+			linux,default-trigger-delay-ms = <0>;
+		};
+	};
+
+	/* If hdmirx node is disabled, delete the reserved-memory node here. */
+	reserved-memory {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		ranges;
+
+		/* Reserve 256MB memory for hdmirx-controller@fdee0000 */
+		cma {
+			compatible = "shared-dma-pool";
+			reusable;
+			reg = <0x0 (256 * 0x100000) 0x0 (256 * 0x100000)>;
+			linux,cma-default;
+		};
+	};
+
+	vcc12v_dcin: vcc12v-dcin {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc12v_dcin";
+		regulator-always-on;
+		regulator-boot-on;
+		regulator-min-microvolt = <12000000>;
+		regulator-max-microvolt = <12000000>;
+	};
+
+	vcc5v0_sys: vcc5v0-sys {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc5v0_sys";
+		regulator-always-on;
+		regulator-boot-on;
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		vin-supply = <&vcc12v_dcin>;
+	};
+
+	vcc_1v1_nldo_s3: vcc-1v1-nldo-s3 {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc_1v1_nldo_s3";
+		regulator-always-on;
+		regulator-boot-on;
+		regulator-min-microvolt = <1100000>;
+		regulator-max-microvolt = <1100000>;
+		vin-supply = <&vcc5v0_sys>;
+	 };
+
+	vcc_3v3_sd_s0: vcc-3v3-sd-s0 {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc_3v3_sd_s0";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		gpios = <&gpio3 RK_PD5 GPIO_ACTIVE_LOW>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&sdmmc_pwr>;
+		enable-active-low;
+	};
+
+	vcc5v0_usbdcin: vcc5v0-usbdcin {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc5v0_usbdcin";
+		regulator-always-on;
+		regulator-boot-on;
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		vin-supply = <&vcc12v_dcin>;
+	};
+
+	vcc5v0_usb: vcc5v0-usb {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc5v0_usb";
+		regulator-always-on;
+		regulator-boot-on;
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		vin-supply = <&vcc5v0_usbdcin>;
+	};
+
+	vcc5v0_host: vcc5v0-host {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc5v0_host";
+		regulator-boot-on;
+		regulator-always-on;
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		enable-active-high;
+		gpio = <&gpio3 RK_PB7 GPIO_ACTIVE_HIGH>;
+		vin-supply = <&vcc5v0_usb>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&vcc5v0_host_en>;
+	};
+
+	vbus5v0_typec: vbus5v0-typec {
+		compatible = "regulator-fixed";
+		regulator-name = "vbus5v0_typec";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		enable-active-high;
+		gpio = <&gpio4 RK_PB0 GPIO_ACTIVE_HIGH>;
+		vin-supply = <&vcc5v0_usb>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&typec5v_pwren>;
+	};
+
+	vcc3v3_pcie30: vcc3v3-pcie30 {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc3v3_pcie30";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		enable-active-high;
+		gpios = <&gpio2 RK_PB6 GPIO_ACTIVE_HIGH>;
+		startup-delay-us = <5000>;
+		vin-supply = <&vcc5v0_sys>;
+	};
+
+	vcc3v3_pcie2x1l0: vcc3v3-pcie2x1l0 {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc3v3_pcie2x1l0";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		enable-active-high;
+		gpios = <&gpio2 RK_PC5 GPIO_ACTIVE_HIGH>;
+		startup-delay-us = <50000>;
+		vin-supply = <&vcc12v_dcin>;
+	};
+
+	vcc3v3_pcie_eth: vcc3v3-pcie-eth {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc3v3_pcie_eth";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-boot-on;
+		regulator-always-on;
+		enable-active-low;
+		gpios = <&gpio3 RK_PB4 GPIO_ACTIVE_LOW>;
+		startup-delay-us = <50000>;
+		vin-supply = <&vcc12v_dcin>;
+	};
+
+	vcc_mipicsi0: vcc-mipicsi0-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc_mipicsi0";
+		enable-active-high;
+	};
+
+	vcc_mipicsi1: vcc-mipicsi1-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc_mipicsi1";
+		enable-active-high;
+	};
+
+	vcc_mipidcphy0: vcc-mipidcphy0-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc_mipicsi1";
+		enable-active-high;
+	};
+
+	wireless_bluetooth: wireless-bluetooth {
+		compatible = "bluetooth-platdata";
+		clocks = <&hym8563>;
+		clock-names = "ext_clock";
+		uart_rts_gpios = <&gpio4 RK_PC4 GPIO_ACTIVE_LOW>;
+		pinctrl-names = "default", "rts_gpio";
+		pinctrl-0 = <&uart9m0_rtsn>, <&bt_reset_gpio>, <&bt_wake_gpio>, <&bt_irq_gpio>;
+		pinctrl-1 = <&uart9_gpios>;
+		BT,reset_gpio    = <&gpio0 RK_PC5 GPIO_ACTIVE_HIGH>;
+		BT,wake_gpio     = <&gpio4 RK_PC6 GPIO_ACTIVE_HIGH>;
+		BT,wake_host_irq = <&gpio0 RK_PA0 GPIO_ACTIVE_HIGH>;
+		status = "okay";
+	};
+
+	wireless_wlan: wireless-wlan {
+		compatible = "wlan-platdata";
+		wifi_chip_type = "ap6275p";
+		pinctrl-names = "default";
+		pinctrl-0 = <&wifi_host_wake_irq>;
+		WIFI,host_wake_irq = <&gpio0 RK_PB0 GPIO_ACTIVE_HIGH>;
+		status = "okay";
+	};
+
+	wifi_disable: wifi-diable-gpio-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "wifi_disable";
+		enable-active-high;
+		gpio = <&gpio0 RK_PC4 GPIO_ACTIVE_HIGH>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+};
+
+&av1d {
+	status = "okay";
+};
+
+&av1d_mmu {
+	status = "okay";
+};
+
+&avsd {
+	status = "okay";
+};
+
+&can0 {
+	status = "disabled";
+	pinctrl-names = "default";
+	pinctrl-0 = <&can0m0_pins>;
+	assigned-clocks = <&cru CLK_CAN0>;
+	assigned-clock-rates = <200000000>;
+};
+
+&can1 {
+	status = "disabled";
+	pinctrl-names = "default";
+	pinctrl-0 = <&can1m0_pins>;
+	assigned-clocks = <&cru CLK_CAN1>;
+	assigned-clock-rates = <200000000>;
+};
+
+&can2 {
+	status = "disabled";
+};
+
+&cpu_l0 {
+	cpu-supply = <&vdd_cpu_lit_s0>;
+	mem-supply = <&vdd_cpu_lit_mem_s0>;
+};
+
+&cpu_b0 {
+	cpu-supply = <&vdd_cpu_big0_s0>;
+	mem-supply = <&vdd_cpu_big0_mem_s0>;
+};
+
+&cpu_b2 {
+	cpu-supply = <&vdd_cpu_big1_s0>;
+	mem-supply = <&vdd_cpu_big1_mem_s0>;
+};
+
+&combphy0_ps {
+	status = "okay";
+};
+
+&combphy1_ps {
+	status = "okay";
+};
+
+&combphy2_psu {
+    status = "okay";
+};
+
+&display_subsystem {
+    clocks = <&hdptxphy_hdmi0>, <&hdptxphy_hdmi1>;
+    clock-names = "hdmi0_phy_pll", "hdmi1_phy_pll";
+};
+
+&dp0 {
+    status = "okay";
+};
+
+&dp0_in_vp2 {
+    status = "okay";
+};
+
+&gpu {
+    mali-supply = <&vdd_gpu_s0>;
+    mem-supply = <&vdd_gpu_mem_s0>;
+    status = "okay";
+};
+
+&hdmi0 {
+    status = "okay";
+    enable-gpios = <&gpio4 RK_PB1 GPIO_ACTIVE_HIGH>;
+    cec-enable = "true";
+};
+
+&hdmi0_in_vp0 {
+    status = "okay";
+};
+
+&hdmi1 {
+    status = "okay";
+    enable-gpios = <&gpio4 RK_PB2 GPIO_ACTIVE_HIGH>;
+    cec-enable = "true";
+};
+
+&hdmi1_in_vp1 {
+    status = "okay";
+};
+
+/* Should work with at least 128MB cma reserved above. */
+&hdmirx_ctrler {
+    status = "disabled";
+
+    #sound-dai-cells = <1>;
+    /* Effective level used to trigger HPD: 0-low, 1-high */
+    hpd-trigger-level = <1>;
+    hdmirx-det-gpios = <&gpio1 RK_PC6 GPIO_ACTIVE_LOW>;
+
+    pinctrl-names = "default";
+    pinctrl-0 = <&hdmim1_rx_cec &hdmim1_rx_hpdin &hdmim1_rx_scl &hdmim1_rx_sda &hdmirx_det>;
+};
+
+&hdptxphy_hdmi0 {
+    status = "okay";
+};
+
+&hdptxphy_hdmi1 {
+    status = "okay";
+};
+
+&hdptxphy_hdmi0 {
+	status = "okay";
+};
+
+&hdptxphy_hdmi1 {
+	status = "okay";
+};
+
+&iep {
+    status = "okay";
+};
+
+&iep_mmu {
+    status = "okay";
+};
+
+&jpegd {
+    status = "okay";
+};
+
+&jpegd_mmu {
+    status = "okay";
+};
+
+&jpege_ccu {
+    status = "okay";
+};
+&jpege0 {
+    status = "okay";
+};
+
+&jpege0_mmu {
+    status = "okay";
+};
+
+&jpege1 {
+    status = "okay";
+};
+
+&jpege1_mmu {
+    status = "okay";
+};
+
+&jpege2 {
+    status = "okay";
+};
+
+&jpege2_mmu {
+    status = "okay";
+};
+
+&jpege3 {
+    status = "okay";
+};
+
+&jpege3_mmu {
+    status = "okay";
+};
+
+&mpp_srv {
+    status = "okay";
+};
+
+&rga3_core0 {
+    status = "okay";
+};
+
+&rga3_0_mmu {
+    status = "okay";
+};
+
+&rga3_core1 {
+    status = "okay";
+};
+
+&rga3_1_mmu {
+    status = "okay";
+};
+
+&rga2 {
+    status = "okay";
+};
+
+&rknpu {
+    rknpu-supply = <&vdd_npu_s0>;
+    mem-supply = <&vdd_npu_mem_s0>;
+    status = "okay";
+};
+
+&rknpu_mmu {
+    status = "okay";
+};
+
+&rkvdec_ccu {
+    status = "okay";
+};
+
+&rkvdec0 {
+    status = "okay";
+};
+
+&rkvdec0_mmu {
+    status = "okay";
+};
+
+&rkvdec1 {
+    status = "okay";
+};
+
+&rkvdec1_mmu {
+    status = "okay";
+};
+
+&rkvenc_ccu {
+    status = "okay";
+};
+
+&rkvenc0 {
+    status = "okay";
+};
+
+&rkvenc0_mmu {
+    status = "okay";
+};
+
+&rkvenc1 {
+    status = "okay";
+};
+
+&rkvenc1_mmu {
+    status = "okay";
+};
+
+&rockchip_suspend {
+    status = "okay";
+    rockchip,sleep-debug-en = <1>;
+};
+
+&vdpu {
+    status = "okay";
+};
+
+&vdpu_mmu {
+    status = "okay";
+};
+
+&vepu {
+    status = "okay";
+};
+
+&i2c0 {
+    status = "okay";
+    pinctrl-names = "default";
+    pinctrl-0 = <&i2c0m2_xfer>;
+
+    vdd_cpu_big0_s0: vdd_cpu_big0_mem_s0: rk8602@42 {
+        compatible = "rockchip,rk8602";
+        reg = <0x42>;
+        vin-supply = <&vcc5v0_sys>;
+        regulator-compatible = "rk860x-reg";
+        regulator-name = "vdd_cpu_big0_s0";
+        regulator-min-microvolt = <550000>;
+        regulator-max-microvolt = <1050000>;
+        regulator-ramp-delay = <2300>;
+        rockchip,suspend-voltage-selector = <1>;
+        regulator-boot-on;
+        regulator-always-on;
+        regulator-state-mem {
+            regulator-off-in-suspend;
+        };
+    };
+
+    vdd_cpu_big1_s0: vdd_cpu_big1_mem_s0: rk8603@43 {
+        compatible = "rockchip,rk8603";
+        reg = <0x43>;
+        vin-supply = <&vcc5v0_sys>;
+        regulator-compatible = "rk860x-reg";
+        regulator-name = "vdd_cpu_big1_s0";
+        regulator-min-microvolt = <550000>;
+        regulator-max-microvolt = <1050000>;
+        regulator-ramp-delay = <2300>;
+        rockchip,suspend-voltage-selector = <1>;
+        regulator-boot-on;
+        regulator-always-on;
+        regulator-state-mem {
+            regulator-off-in-suspend;
+        };
+    };
+};
+
+&i2c1 {
+    status = "okay";
+    pinctrl-names = "default";
+    pinctrl-0 = <&i2c1m2_xfer>;
+
+    vdd_npu_s0: vdd_npu_mem_s0: rk8602@42 {
+        compatible = "rockchip,rk8602";
+        reg = <0x42>;
+        vin-supply = <&vcc5v0_sys>;
+        regulator-compatible = "rk860x-reg";
+        regulator-name = "vdd_npu_s0";
+        regulator-min-microvolt = <550000>;
+        regulator-max-microvolt = <950000>;
+        regulator-ramp-delay = <2300>;
+        rockchip,suspend-voltage-selector = <1>;
+        regulator-boot-on;
+        regulator-always-on;
+        regulator-state-mem {
+            regulator-off-in-suspend;
+        };
+    };
+};
+
+&i2c2 {
+    status = "disabled";
+    pinctrl-names = "default";
+    pinctrl-0 = <&i2c2m4_xfer>;
+};
+
+&i2c4 {
+    status = "disabled";
+    pinctrl-names = "default";
+    pinctrl-0 = <&i2c4m3_xfer>;
+};
+
+&i2c5 {
+    status = "disabled";
+    pinctrl-names = "default";
+    pinctrl-0 = <&i2c5m3_xfer>;
+};
+
+&i2c6 {
+    status = "okay";
+    clock-frequency = <400000>;
+    pinctrl-names = "default";
+    pinctrl-0 = <&i2c6m0_xfer>;
+
+    usbc0: fusb302@22 {
+        compatible = "fcs,fusb302";
+        reg = <0x22>;
+        interrupt-parent = <&gpio0>;
+        interrupts = <RK_PD3 IRQ_TYPE_LEVEL_LOW>;
+        pinctrl-names = "default";
+        pinctrl-0 = <&usbc0_int>;
+        vbus-supply = <&vbus5v0_typec>;
+        status = "okay";
+
+        ports {
+            #address-cells = <1>;
+            #size-cells = <0>;
+
+            port@0 {
+                reg = <0>;
+                usbc0_role_sw: endpoint@0 {
+                    remote-endpoint = <&dwc3_0_role_switch>;
+                };
+            };
+        };
+
+        usb_con: connector {
+            compatible = "usb-c-connector";
+            label = "USB-C";
+            data-role = "dual";
+            power-role = "dual";
+            try-power-role = "sink";
+            op-sink-microwatt = <1000000>;
+            sink-pdos =
+                <PDO_FIXED(5000, 1000, PDO_FIXED_USB_COMM)>;
+            source-pdos =
+                <PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)>;
+
+            altmodes {
+                #address-cells = <1>;
+                #size-cells = <0>;
+
+                altmode@0 {
+                    reg = <0>;
+                    svid = <0xff01>;
+                    vdo = <0xffffffff>;
+                };
+            };
+
+            ports {
+                #address-cells = <1>;
+                #size-cells = <0>;
+
+                port@0 {
+                    reg = <0>;
+                    usbc0_orien_sw: endpoint {
+                        remote-endpoint = <&usbdp_phy0_orientation_switch>;
+                    };
+                };
+
+                port@1 {
+                    reg = <1>;
+                    dp_altmode_mux: endpoint {
+                        remote-endpoint = <&usbdp_phy0_dp_altmode_mux>;
+                    };
+                };
+            };
+        };
+    };
+
+    hym8563: hym8563@51 {
+        compatible = "haoyu,hym8563";
+        reg = <0x51>;
+        #clock-cells = <0>;
+        clock-frequency = <32768>;
+        clock-output-names = "hym8563";
+        pinctrl-names = "default";
+        pinctrl-0 = <&hym8563_int>;
+        interrupt-parent = <&gpio0>;
+        interrupts = <RK_PC6 IRQ_TYPE_LEVEL_LOW>;
+        status = "okay";
+    };
+
+};
+
+&i2c7 {
+    status = "okay";
+
+    es8388: es8388@11 {
+        status = "okay";
+        #sound-dai-cells = <0>;
+        compatible = "everest,es8388", "everest,es8323";
+        reg = <0x11>;
+        clocks = <&mclkout_i2s0>;
+        clock-names = "mclk";
+        assigned-clocks = <&mclkout_i2s0>;
+        assigned-clock-rates = <12288000>;
+        pinctrl-names = "default";
+        pinctrl-0 = <&i2s0_mclk>;
+    };
+};
+
+&i2c8 {
+    status = "disabled";
+    pinctrl-names = "default";
+    pinctrl-0 = <&i2c8m2_xfer>;
+};
+
+&i2s0_8ch {
+    status = "okay";
+    pinctrl-0 = <&i2s0_lrck
+             &i2s0_sclk
+             &i2s0_sdi0
+             &i2s0_sdo0>;
+};
+
+&i2s5_8ch {
+    status = "okay";
+};
+
+&i2s6_8ch {
+    status = "okay";
+};
+
+&i2s7_8ch {
+    status = "okay";
+};
+
+//phy1
+&pcie2x1l0 {
+    reset-gpios = <&gpio4 RK_PA5 GPIO_ACTIVE_HIGH>;
+    vpcie3v3-supply = <&vcc3v3_pcie2x1l0>;
+    rockchip,skip-scan-in-resume;
+    status = "okay";
+};
+
+//phy2
+&pcie2x1l1 {
+    reset-gpios = <&gpio3 RK_PB3 GPIO_ACTIVE_HIGH>;
+    vpcie3v3-supply = <&vcc3v3_pcie_eth>;
+    status = "okay";
+};
+
+//phy0
+&pcie2x1l2 {
+    reset-gpios = <&gpio4 RK_PA2 GPIO_ACTIVE_HIGH>;
+    vpcie3v3-supply = <&vcc3v3_pcie_eth>;
+    status = "okay";
+};
+
+&pcie30phy {
+    status = "okay";
+};
+
+&pcie3x4 {
+    reset-gpios = <&gpio4 RK_PB6 GPIO_ACTIVE_HIGH>;
+    vpcie3v3-supply = <&vcc3v3_pcie30>;
+    status = "okay";
+};
+
+&pinctrl {
+    hdmi {
+        hdmirx_det: hdmirx-det {
+            rockchip,pins = <1 RK_PC6 RK_FUNC_GPIO &pcfg_pull_up>;
+        };
+    };
+
+    headphone {
+        hp_det: hp-det {
+            rockchip,pins = <1 RK_PD3 RK_FUNC_GPIO &pcfg_pull_none>;
+        };
+    };
+
+    hym8563 {
+        hym8563_int: hym8563-int {
+            rockchip,pins = <0 RK_PC6 RK_FUNC_GPIO &pcfg_pull_up>;
+        };
+    };
+
+    leds_gpio {
+        leds_rgb: leds-rgb {
+                rockchip,pins = <3 RK_PA6 RK_FUNC_GPIO &pcfg_pull_up>,
+                    <3 RK_PB1 RK_FUNC_GPIO &pcfg_pull_up>;
+        };
+    };
+
+    lcd {
+        lcd_rst_gpio: lcd-rst-gpio {
+            rockchip,pins = <2 RK_PC1 RK_FUNC_GPIO &pcfg_pull_none>;
+        };
+    };
+
+    usb {
+        vcc5v0_host_en: vcc5v0-host-en {
+            rockchip,pins = <3 RK_PB7 RK_FUNC_GPIO &pcfg_pull_none>;
+        };
+    };
+
+    usb-typec {
+        usbc0_int: usbc0-int {
+            rockchip,pins = <0 RK_PD3 RK_FUNC_GPIO &pcfg_pull_up>;
+        };
+
+        typec5v_pwren: typec5v-pwren {
+            rockchip,pins = <4 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>;
+        };
+    };
+
+    wireless-bluetooth {
+        uart9_gpios: uart9-gpios {
+            rockchip,pins = <4 RK_PC4 RK_FUNC_GPIO &pcfg_pull_none>;
+        };
+
+        bt_reset_gpio: bt-reset-gpio {
+            rockchip,pins = <0 RK_PC5 RK_FUNC_GPIO &pcfg_pull_none>;
+        };
+
+        bt_wake_gpio: bt-wake-gpio {
+            rockchip,pins = <4 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>;
+        };
+
+        bt_irq_gpio: bt-irq-gpio {
+            rockchip,pins = <0 RK_PA0 RK_FUNC_GPIO &pcfg_pull_down>;
+        };
+    };
+
+    wireless-wlan {
+        wifi_host_wake_irq: wifi-host-wake-irq {
+            rockchip,pins = <0 RK_PB0 RK_FUNC_GPIO &pcfg_pull_down>;
+        };
+    };
+
+    sdmmc {
+        sdmmc_pwr: sdmmc_pwr {
+            rockchip,pins = <3 RK_PD5 RK_FUNC_GPIO &pcfg_pull_down>;
+        };
+    };
+};
+
+&pwm0 {
+    status = "disabled";
+};
+
+&pwm1 {
+    status = "disabled";
+};
+
+&pwm3 {
+    status = "okay";
+    pinctrl-names = "active";
+    pinctrl-0 = <&pwm3m1_pins>;
+};
+
+&pwm10 {
+    status = "disabled";
+    pinctrl-names = "active";
+    pinctrl-0 = <&pwm10m0_pins>;
+};
+
+&pwm11 {
+    status = "disabled";
+    pinctrl-names = "active";
+    pinctrl-0 = <&pwm11m0_pins>;
+};
+
+&pwm12 {
+    status = "disabled";
+    pinctrl-names = "active";
+    pinctrl-0 = <&pwm12m0_pins>;
+};
+
+&pwm13 {
+    status = "disabled";
+    pinctrl-names = "active";
+    pinctrl-0 = <&pwm13m2_pins>;
+};
+
+&pwm14 {
+    status = "disabled";
+};
+
+&pwm15 {
+    compatible = "rockchip,remotectl-pwm";
+    pinctrl-names = "default";
+    pinctrl-0 = <&pwm15m1_pins>;
+    remote_pwm_id = <3>;
+    handle_cpu_id = <1>;
+    remote_support_psci = <0>;
+    status = "okay";
+
+    ir_key1 {
+        rockchip,usercode = <0xfb04>;
+        rockchip,key_table =
+            <0xa3   KEY_ENTER>,
+            <0xe4   388>,
+            <0xf5   KEY_BACK>,
+            <0xbb   KEY_UP>,
+            <0xe2   KEY_DOWN>,
+            <0xe3   KEY_LEFT>,
+            <0xb7   KEY_RIGHT>,
+            <0xe0   KEY_HOME>,
+            <0xba   KEY_VOLUMEUP>,
+            <0xda   KEY_VOLUMEUP>,
+            <0xe6   KEY_VOLUMEDOWN>,
+            <0xdb   KEY_VOLUMEDOWN>,
+            <0xbc   KEY_SEARCH>,
+            <0xb2   KEY_POWER>,
+            <0xe5   KEY_POWER>,
+            <0xde   KEY_POWER>,
+            <0xdc   KEY_MUTE>,
+            <0xa2   KEY_MENU>,
+            <0xec   KEY_1>,
+            <0xef   KEY_2>,
+            <0xee   KEY_3>,
+            <0xf0   KEY_4>,
+            <0xf3   KEY_5>,
+            <0xf2   KEY_6>,
+            <0xf4   KEY_7>,
+            <0xf7   KEY_8>,
+            <0xf6   KEY_9>,
+            <0xb8   KEY_0>;
+    };
+};
+
+&sata0 {
+    status = "disabled";
+};
+
+&saradc {
+    status = "okay";
+    vref-supply = <&vcc_1v8_s0>;
+};
+
+&spi0 {
+    status = "disabled";
+    assigned-clocks = <&cru CLK_SPI0>;
+    assigned-clock-rates = <200000000>;
+    num-cs = <2>;
+};
+
+
+&spi4 {
+    status = "disabled";
+    assigned-clocks = <&cru CLK_SPI4>;
+    assigned-clock-rates = <200000000>;
+    num-cs = <2>;
+};
+
+&sfc {
+    status = "okay";
+    max-freq = <100000000>;
+    #address-cells = <1>;
+    #size-cells = <0>;
+    pinctrl-names = "default";
+    pinctrl-0 = <&fspim1_pins>;
+
+    spi_flash: spi-flash@0 {
+        #address-cells = <1>;
+        #size-cells = <0>;
+        compatible = "jedec,spi-nor";
+        reg = <0x0>;
+        spi-max-frequency = <100000000>;
+        spi-tx-bus-width = <1>;
+        spi-rx-bus-width = <4>;
+        status = "okay";
+
+        partitions {
+            compatible = "fixed-partitions";
+            #address-cells = <1>;
+            #size-cells = <1>;
+
+            loader@0 {
+                label = "loader";
+                reg = <0x0 0x1000000>;
+            };
+        };
+    };
+};
+
+&sdhci {
+    bus-width = <8>;
+    no-sdio;
+    no-sd;
+    non-removable;
+    max-frequency = <200000000>;
+    mmc-hs400-1_8v;
+    mmc-hs400-enhanced-strobe;
+    status = "okay";
+};
+
+&sdmmc {
+    max-frequency = <150000000>;
+    no-sdio;
+    no-mmc;
+    bus-width = <4>;
+    cap-mmc-highspeed;
+    cap-sd-highspeed;
+    disable-wp;
+    sd-uhs-sdr104;
+    vmmc-supply = <&vcc_3v3_sd_s0>;
+    vqmmc-supply = <&vccio_sd_s0>;
+    status = "okay";
+};
+
+&spdif_tx2 {
+    status = "okay";
+};
+
+&uart1 {
+    status = "disabled";
+    pinctrl-names = "default";
+    pinctrl-0 = <&uart1m1_xfer>;
+};
+
+&uart3 {
+    status = "disabled";
+    pinctrl-names = "default";
+    pinctrl-0 = <&uart3m1_xfer>;
+};
+
+&uart4 {
+    status = "disabled";
+    pinctrl-names = "default";
+    pinctrl-0 = <&uart4m2_xfer>;
+};
+
+&uart6 {
+    status = "disabled";
+    pinctrl-names = "default";
+    pinctrl-0 = <&uart6m1_xfer>;
+};
+
+&uart7 {
+    status = "disabled";
+    pinctrl-names = "default";
+    pinctrl-0 = <&uart7m2_xfer>;
+};
+
+&uart8 {
+    status = "disabled";
+    pinctrl-names = "default";
+    pinctrl-0 = <&uart8m1_xfer>;
+};
+
+&uart9 {
+    status = "okay";
+    pinctrl-names = "default";
+    pinctrl-0 = <&uart9m0_xfer &uart9m0_ctsn>;
+};
+
+&u2phy0 {
+    status = "okay";
+};
+
+&u2phy1 {
+    status = "okay";
+};
+
+&u2phy2 {
+    status = "okay";
+};
+
+&u2phy3 {
+    status = "okay";
+};
+
+&u2phy0_otg {
+    rockchip,typec-vbus-det;
+    status = "okay";
+};
+
+&u2phy1_otg {
+    phy-supply = <&vcc5v0_host>;
+    status = "okay";
+};
+
+&u2phy2_host {
+    phy-supply = <&vcc5v0_host>;
+    status = "okay";
+};
+
+&u2phy3_host {
+    phy-supply = <&vcc5v0_host>;
+    status = "okay";
+};
+
+&usb_host0_ehci {
+    status = "okay";
+};
+
+&usb_host0_ohci {
+    status = "okay";
+};
+
+&usb_host1_ehci {
+    status = "okay";
+};
+
+&usb_host1_ohci {
+    status = "okay";
+};
+
+&usbdp_phy0 {
+    orientation-switch;
+    svid = <0xff01>;
+    sbu1-dc-gpios = <&gpio4 RK_PA6 GPIO_ACTIVE_HIGH>;
+    sbu2-dc-gpios = <&gpio4 RK_PA7 GPIO_ACTIVE_HIGH>;
+    status = "okay";
+
+    port {
+        #address-cells = <1>;
+        #size-cells = <0>;
+        usbdp_phy0_orientation_switch: endpoint@0 {
+            reg = <0>;
+            remote-endpoint = <&usbc0_orien_sw>;
+        };
+
+        usbdp_phy0_dp_altmode_mux: endpoint@1 {
+            reg = <1>;
+            remote-endpoint = <&dp_altmode_mux>;
+        };
+    };
+};
+
+&usbdp_phy0_dp {
+    status = "okay";
+};
+
+&usbdp_phy0_u3 {
+    status = "okay";
+};
+
+&usbdp_phy1 {
+    rockchip,dp-lane-mux = <2 3>;
+    status = "okay";
+};
+
+&usbdp_phy1_dp {
+    status = "okay";
+};
+
+&usbdp_phy1_u3 {
+    status = "okay";
+};
+
+&usbdrd_dwc3_0 {
+    status = "okay";
+    dr_mode = "otg";
+    usb-role-switch;
+    port {
+        #address-cells = <1>;
+        #size-cells = <0>;
+        dwc3_0_role_switch: endpoint@0 {
+            reg = <0>;
+            remote-endpoint = <&usbc0_role_sw>;
+        };
+    };
+};
+
+&usbdrd3_0 {
+    status = "okay";
+};
+
+&usbdrd3_1 {
+    status = "okay";
+};
+
+&usbdrd_dwc3_1 {
+    dr_mode = "host";
+    status = "okay";
+};
+
+&vop {
+    status = "okay";
+    disable-win-move;
+    assigned-clocks = <&cru ACLK_VOP>;
+    assigned-clock-rates = <800000000>;
+};
+
+&vop_mmu {
+    status = "okay";
+};
+
+/* vp0 & vp1 splice for 8K output */
+&vp0 {
+    cursor-win-id=<ROCKCHIP_VOP2_ESMART0>;
+    rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER0 | 1 << ROCKCHIP_VOP2_ESMART0)>;
+    rockchip,primary-plane = <ROCKCHIP_VOP2_CLUSTER0>;
+};
+
+&vp1 {
+    cursor-win-id=<ROCKCHIP_VOP2_ESMART1>;
+    rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER1 | 1 << ROCKCHIP_VOP2_ESMART1)>;
+    rockchip,primary-plane = <ROCKCHIP_VOP2_CLUSTER1>;
+};
+
+&vp2 {
+    cursor-win-id=<ROCKCHIP_VOP2_ESMART2>;
+    rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER2 | 1 << ROCKCHIP_VOP2_ESMART2)>;
+    rockchip,primary-plane = <ROCKCHIP_VOP2_CLUSTER2>;
+};
+
+&vp3 {
+    cursor-win-id=<ROCKCHIP_VOP2_ESMART3>;
+    rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER3 | 1 << ROCKCHIP_VOP2_ESMART3)>;
+    rockchip,primary-plane = <ROCKCHIP_VOP2_CLUSTER3>;
+};
+
+&wdt {
+    status = "okay";
+};
+
+&tsadc {
+    status = "okay";
+};

--- a/target/linux/rockchip/dts/rk3588/rk3588-orangepi-5-plus.dts
+++ b/target/linux/rockchip/dts/rk3588/rk3588-orangepi-5-plus.dts
@@ -346,8 +346,8 @@
 		pinctrl-names = "default", "rts_gpio";
 		pinctrl-0 = <&uart9m0_rtsn>, <&bt_reset_gpio>, <&bt_wake_gpio>, <&bt_irq_gpio>;
 		pinctrl-1 = <&uart9_gpios>;
-		BT,reset_gpio    = <&gpio0 RK_PC5 GPIO_ACTIVE_HIGH>;
-		BT,wake_gpio     = <&gpio4 RK_PC6 GPIO_ACTIVE_HIGH>;
+		BT,reset_gpio = <&gpio0 RK_PC5 GPIO_ACTIVE_HIGH>;
+		BT,wake_gpio = <&gpio4 RK_PC6 GPIO_ACTIVE_HIGH>;
 		BT,wake_host_irq = <&gpio0 RK_PA0 GPIO_ACTIVE_HIGH>;
 		status = "okay";
 	};

--- a/target/linux/rockchip/dts/rk3588/rk3588-orangepi-5-plus.dts
+++ b/target/linux/rockchip/dts/rk3588/rk3588-orangepi-5-plus.dts
@@ -862,7 +862,6 @@
 //phy2
 &pcie2x1l1 {
     reset-gpios = <&gpio3 RK_PB3 GPIO_ACTIVE_HIGH>;
-    prsnt-gpios = <&gpio3 RK_PB3 GPIO_ACTIVE_HIGH>;
     vpcie3v3-supply = <&vcc3v3_pcie_eth>;
     status = "okay";
 };
@@ -870,7 +869,6 @@
 //phy0
 &pcie2x1l2 {
     reset-gpios = <&gpio4 RK_PA2 GPIO_ACTIVE_HIGH>;
-    prsnt-gpios = <&gpio4 RK_PA2 GPIO_ACTIVE_HIGH>;
     vpcie3v3-supply = <&vcc3v3_pcie_eth>;
     status = "okay";
 };

--- a/target/linux/rockchip/image/rk35xx.mk
+++ b/target/linux/rockchip/image/rk35xx.mk
@@ -257,7 +257,7 @@ define Device/xunlong_orangepi-5-plus
 $(call Device/rk3588)
   DEVICE_VENDOR := XunLong
   DEVICE_MODEL := Orange Pi 5 Plus
-  DEVICE_PACKAGES := kmod-r8125 kmod-r8169 kmod-nvme kmod-scsi-core kmod-hwmon-pwmfan kmod-thermal kmod-rkwifi-bcmdhd-pcie rkwifi-firmware-ap6275p
+  DEVICE_PACKAGES := kmod-r8125 kmod-nvme kmod-scsi-core kmod-hwmon-pwmfan kmod-thermal kmod-rkwifi-bcmdhd-pcie rkwifi-firmware-ap6275p
   SUPPORTED_DEVICES += xunlong,orangepi-5-plus
   DEVICE_DTS := rk3588-orangepi-5-plus
 endef

--- a/target/linux/rockchip/image/rk35xx.mk
+++ b/target/linux/rockchip/image/rk35xx.mk
@@ -253,6 +253,16 @@ $(call Device/rk3588)
 endef
 TARGET_DEVICES += yijiahe_jm10
 
+define Device/xunlong_orangepi-5-plus
+$(call Device/rk3588)
+  DEVICE_VENDOR := XunLong
+  DEVICE_MODEL := Orange Pi 5 Plus
+  DEVICE_PACKAGES := kmod-r8125 kmod-r8169 kmod-nvme kmod-scsi-core kmod-hwmon-pwmfan kmod-thermal kmod-rkwifi-bcmdhd-pcie rkwifi-firmware-ap6275p
+  SUPPORTED_DEVICES += xunlong,orangepi-5-plus
+  DEVICE_DTS := rk3588-orangepi-5-plus
+endef
+TARGET_DEVICES += xunlong_orangepi-5-plus
+
 define Device/hinlink_rk3588
 $(call Device/rk3588)
   DEVICE_VENDOR := HINLINK

--- a/target/linux/rockchip/rk35xx/base-files/etc/board.d/02_network
+++ b/target/linux/rockchip/rk35xx/base-files/etc/board.d/02_network
@@ -25,6 +25,7 @@ rockchip_setup_interfaces()
 	jsy,h1|\
 	nlnet,xgp|\
 	radxa,e52c|\
+	xunlong,orangepi-5-plus|\
 	firefly,rk3568-roc-pc)
 		ucidef_set_interfaces_lan_wan 'eth1' 'eth0'
 		;;
@@ -52,7 +53,6 @@ rockchip_setup_interfaces()
 		;;
 	ezpro,mrkaio-m68s|\
 	ezpro,mrkaio-m68s-plus|\
-	xunlong,orangepi-5-plus|\
 	radxa,e20c|\
 	mangopi,m28k|\
 	hlink,h28k)

--- a/target/linux/rockchip/rk35xx/base-files/etc/board.d/02_network
+++ b/target/linux/rockchip/rk35xx/base-files/etc/board.d/02_network
@@ -52,6 +52,7 @@ rockchip_setup_interfaces()
 		;;
 	ezpro,mrkaio-m68s|\
 	ezpro,mrkaio-m68s-plus|\
+	xunlong,orangepi-5-plus|\
 	radxa,e20c|\
 	mangopi,m28k|\
 	hlink,h28k)
@@ -142,6 +143,7 @@ rockchip_setup_macs()
 	lyt,t68m|\
 	lyt,t88m|\
 	yijiahe,jm10|\
+	xunlong,orangepi-5-plus|\
 	mangopi,m28k|\
 	nlnet,xgp|\
 	radxa,e20c|\

--- a/target/linux/rockchip/rk35xx/base-files/etc/board.d/02_network
+++ b/target/linux/rockchip/rk35xx/base-files/etc/board.d/02_network
@@ -25,7 +25,6 @@ rockchip_setup_interfaces()
 	jsy,h1|\
 	nlnet,xgp|\
 	radxa,e52c|\
-	xunlong,orangepi-5-plus|\
 	firefly,rk3568-roc-pc)
 		ucidef_set_interfaces_lan_wan 'eth1' 'eth0'
 		;;
@@ -53,6 +52,7 @@ rockchip_setup_interfaces()
 		;;
 	ezpro,mrkaio-m68s|\
 	ezpro,mrkaio-m68s-plus|\
+	xunlong,orangepi-5-plus|\
 	radxa,e20c|\
 	mangopi,m28k|\
 	hlink,h28k)


### PR DESCRIPTION
已测试几次并且执行重置几次，两个2.5g网口都正常了，我家没2.5g设备，都是千兆的设备，eth1是百兆的原因是type-c转网口本来就是百兆的hub。
![IMG_20250628_053636](https://github.com/user-attachments/assets/78a066ff-55ea-4280-b387-1bc598624e4a)
![IMG_20250628_053738](https://github.com/user-attachments/assets/562e80fa-f8c0-43a3-a158-a8d265ca7fb1)
