### PR TITLE
change orangepi 5 plus rtl8125 driver to r8169

### DIFF
--- a/target/linux/rockchip/image/rk35xx.mk
+++ b/target/linux/rockchip/image/rk35xx.mk
@@ -257,7 +257,7 @@ define Device/xunlong_orangepi-5-plus
 $(call Device/rk3588)
   DEVICE_VENDOR := XunLong
   DEVICE_MODEL := Orange Pi 5 Plus
-  DEVICE_PACKAGES := kmod-r8125 kmod-nvme kmod-scsi-core kmod-hwmon-pwmfan kmod-thermal kmod-rkwifi-bcmdhd-pcie rkwifi-firmware-ap6275p
+  DEVICE_PACKAGES := kmod-r8169 kmod-nvme kmod-scsi-core kmod-hwmon-pwmfan kmod-thermal kmod-rkwifi-bcmdhd-pcie rkwifi-firmware-ap6275p
   SUPPORTED_DEVICES += xunlong,orangepi-5-plus
   DEVICE_DTS := rk3588-orangepi-5-plus
 endef


### PR DESCRIPTION
Orange Pi 5 Plus板子使用r8125驱动始终有一个2.5G网口不能正常工作，现在换成kmod-r8169驱动就全部正常了。
![IMG20250715212341](https://github.com/user-attachments/assets/44075011-80a4-4656-ae9a-96d5d4da130a)
![Screenshot_2025-07-15-21-22-41-123_mark via](https://github.com/user-attachments/assets/c6f6747e-b304-443e-b899-9b93bd0a0357)
![Screenshot_2025-07-15-21-22-38-033_mark via](https://github.com/user-attachments/assets/07956db0-463f-45b5-891e-702b5972f6f4)
