### PR TITLE
nftables-nojson：fix compile with fullcone

### DIFF
--- a/package/network/utils/nftables/patches/999-11-masq-fullcone-flag.patch
+++ b/package/network/utils/nftables/patches/999-11-masq-fullcone-flag.patch
@@ -75,7 +75,7 @@ diff --git a/src/expression.c b/src/expression.c
 index c0cb7f22..39d2821a 100644
 --- a/src/expression.c
 +++ b/src/expression.c
-@@ -803,6 +803,51 @@ struct expr *range_expr_alloc(const struct location *loc,
+@@ -803,6 +803,55 @@ struct expr *range_expr_alloc(const struct location *loc,
  	return expr;
  }
  
@@ -100,7 +100,11 @@ index c0cb7f22..39d2821a 100644
 +	.type		= EXPR_FULLCONE,
 +	.name		= "fullcone",
 +	.print		= fullcone_expr_print,
-+	.json		= fullcone_expr_json,
++#ifdef ENABLE_JSON
++    .json   = fullcone_expr_json,
++#else
++    .json   = NULL,
++#endif
 +	.clone		= fullcone_expr_clone,
 +	.destroy	= fullcone_expr_destroy,
 +};


### PR DESCRIPTION
修复在编译nftables-nojson出现错误

src/expression.c:827:27: error: 'fullcone_expr_json' undeclared here (not in a function); did you mean 'fullcone_expr_clone'?