### PR TITLE
uboot-rk35xx: fix H28K (RK3528) boot failure

### DIFF
--- a/package/boot/uboot-rk35xx/patches/912-fix-spl-fit-header-corruption.patch
+++ b/package/boot/uboot-rk35xx/patches/912-fix-spl-fit-header-corruption.patch
@@ -1,0 +1,51 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: fix <fix@openwrt>
+Date: Sat, 17 May 2025 00:00:00 +0800
+Subject: [PATCH] fix SPL FIT header corruption by printf/malloc
+
+The header buffer in mmc_load_image_raw_sector is placed at
+CONFIG_SYS_TEXT_BASE - sizeof(image_header_t), which is inside
+the SPL malloc pool (0x00180000 ~ 0x00200000).
+
+When spl_load_simple_fit is called, the first thing it does is
+printf("Trying fit image..."), which internally uses malloc and
+corrupts the fit/header buffer. The subsequent magic check then
+fails, printing "Not fit magic".
+
+Fix: always re-read the sector from disk inside the loop before
+checking magic, instead of reusing the caller's buffer for i=0.
+
+---
+ common/spl/spl_fit.c | 14 ++++++--------
+ 1 file changed, 6 insertions(+), 8 deletions(-)
+
+Index: rk-u-boot/common/spl/spl_fit.c
+===================================================================
+--- rk-u-boot.orig/common/spl/spl_fit.c
++++ rk-u-boot/common/spl/spl_fit.c
+@@ -832,18 +832,16 @@ int spl_load_simple_fit(struct spl_image
+ 	mpb_init_1(*info);
+ #endif
+
+-	printf("Trying fit image at 0x%lx sector\n", sector_offs);
+ 	for (i = 0; i < CONFIG_SPL_FIT_IMAGE_MULTIPLE; i++) {
+-		if (i > 0) {
++		if (i > 0)
+ 			sector_offs +=
+-			   i * ((CONFIG_SPL_FIT_IMAGE_KB << 10) / info->bl_len);
+-			printf("Trying fit image at 0x%lx sector\n", sector_offs);
+-			if (info->read(info, sector_offs, 1, fit) != 1) {
+-				printf("IO error\n");
+-				continue;
+-			}
++			   (CONFIG_SPL_FIT_IMAGE_KB << 10) / info->bl_len;
++
++		printf("Trying fit image at 0x%lx sector\n", sector_offs);
++		if (info->read(info, sector_offs, 1, fit) != 1) {
++			printf("IO error\n");
++			continue;
+ 		}
+-
+ 		if (image_get_magic(fit) != FDT_MAGIC) {
+ 			printf("Not fit magic\n");
+ 			continue;


### PR DESCRIPTION
问题：SPL 报 "Not fit magic" 无法加载 u-boot.itb。

  根因：mmc_load_image_raw_sector 把 FIT header 缓冲区放在 CONFIG_SYS_TEXT_BASE - 64（即 0x001FFFFC0），正好在 SPL malloc
   pool 末端。它读扇区 0x4000 后检查 FDT 魔数通过，调用 spl_load_simple_fit()。但后者上来先 printf("Trying fit
  image...")，printf 内部分配内存踩坏了 header 数据，紧接着的 image_get_magic(fit) 就读到了被破坏的值。

  修复：common/spl/spl_fit.c — 每次循环迭代（包括 i=0）都在 printf 之后重新从磁盘读取扇区再检查魔数，不再信任 caller
  传入的 buffer。