### PR TITLE
istoreos-files: use ERE sed for the apk distfeeds filter

### DIFF
--- a/package/istoreos-files/Makefile
+++ b/package/istoreos-files/Makefile
@@ -53,11 +53,12 @@ define Package/$(PKG_NAME)/postinst
 #!/bin/sh
 
 HOST_SED="$(subst ${STAGING_DIR_HOST},$${STAGING_DIR_HOST},$(SED))"
+HOST_ESED="$(subst ${STAGING_DIR_HOST},$${STAGING_DIR_HOST},$(ESED))"
 HOST_LN="$(subst ${STAGING_DIR_HOST},$${STAGING_DIR_HOST},$(LN))"
 
 [ -n "$${IPKG_INSTROOT}" ] && {
 	$${HOST_SED} 's,^src/gz istoreos_,src/gz openwrt_,g' -e '/^src\/gz openwrt_\(core\|base\|kmods\|luci\|packages\|routing\|telephony\) /!d' "$${IPKG_INSTROOT}/etc/opkg/distfeeds.conf"
-	$${HOST_SED} '\#/(base|kmods/.+|luci|packages|routing|telephony|video)/packages\.adb$$#!d' "$${IPKG_INSTROOT}/etc/apk/repositories.d/distfeeds.list"
+	$${HOST_ESED} '\#/(base|kmods/.+|luci|packages|routing|telephony|video)/packages\.adb$$#!d' "$${IPKG_INSTROOT}/etc/apk/repositories.d/distfeeds.list"
 
 	$${HOST_SED} 's/"192.168.1.1"/"192.168.100.1"/' \
 		"$${IPKG_INSTROOT}/usr/lib/lua/luci/controller/admin/system.lua" \


### PR DESCRIPTION
Refs 907c5ffd806f2bc5833624b1f18b8237e590b905

## Problem

The apk distfeeds filter added in 907c5ff removes **every** entry from
`/etc/apk/repositories.d/distfeeds.list`, not just the private ones. Images
built from `istoreos-25.12` ship with an empty distfeeds.list and therefore
have no official apk repositories at all.

## Root cause

The filter is written with ERE constructs — `(a|b)` and `.+` — but it runs
through `$(SED)`:

```make
# rules.mk
SED:=$(STAGING_DIR_HOST)/bin/sed -i -e        # BRE
ESED:=$(STAGING_DIR_HOST)/bin/sed -E -i -e    # ERE
```

Under BRE, `(`, `|` and `+` are literals, so no line can ever match and `!d`
deletes all of them. The opkg line right above uses correct BRE escaping
(`\(core\|base\|...\)`) and is unaffected.

## Fix

Add `HOST_ESED` (from `$(ESED)`) and use it for that one line. The pattern
itself is unchanged.

## Verification

Against the real 10-line `distfeeds.list` from the base-files package
(x86_64, `CONFIG_USE_APK=y`, `CONFIG_PER_FEED_REPO=y`):

| | lines |
|---|---|
| generated by `FeedSourcesAppendAPK` | 10 |
| after the current filter | **0** |
| after this fix | 8 |

The two lines dropped by the fixed filter are exactly `store` and `third` —
which is what 907c5ff set out to do.

Reproducer for the BRE/ERE behaviour alone:

```console
$ printf '%U/packages/%A/base/packages.adb\n%U/packages/%A/luci/packages.adb\n' > /tmp/df.list
$ sed -i -e '\#/(base|kmods/.+|luci|packages|routing|telephony|video)/packages\.adb$#!d' /tmp/df.list
$ wc -l < /tmp/df.list
0
```

Built and verified on `istoreos-25.12` at 006c61c5, target x86/64 generic:
`/etc/apk/repositories.d/distfeeds.list` goes from 0 bytes to the 8 expected
entries in the resulting rootfs.