### PR TITLE
istoreos-files: drop stale sed targets in postinst

### DIFF
--- a/package/istoreos-files/Makefile
+++ b/package/istoreos-files/Makefile
@@ -60,25 +60,16 @@ HOST_LN="$(subst ${STAGING_DIR_HOST},$${STAGING_DIR_HOST},$(LN))"
 	$${HOST_SED} '\#/(base|kmods/.+|luci|packages|routing|telephony|video)/packages\.adb$$#!d' "$${IPKG_INSTROOT}/etc/apk/repositories.d/distfeeds.list"
 
 	$${HOST_SED} 's/"192.168.1.1"/"192.168.100.1"/' \
-		"$${IPKG_INSTROOT}/usr/lib/lua/luci/controller/admin/system.lua" \
 		"$${IPKG_INSTROOT}/usr/lib/lua/luci/controller/admin/ota.lua" \
 		"$${IPKG_INSTROOT}/bin/config_generate"
 
 	$${HOST_SED} "s/'192\\.168\\.1\\.1'/'192.168.100.1'/; s/'openwrt\\.lan'/window.location.host/" "$${IPKG_INSTROOT}/www/luci-static/resources/view/system/flash.js"
 
-	$${HOST_SED} 's/s\.anonymous = true/s\.anonymous = true\ns\.addremove = true/' "$${IPKG_INSTROOT}/usr/lib/lua/luci/model/cbi/hd_idle.lua"
-
-	$${HOST_SED} 's#"/opt"#"/overlay/upper/opt/docker"#' "$${IPKG_INSTROOT}/usr/lib/lua/luci/model/cbi/admin_system/fstab/mount.lua"
-
 	rm -f "$${IPKG_INSTROOT}/sbin/jffs2reset"
 	$${HOST_LN} /sbin/firstboot "$${IPKG_INSTROOT}/sbin/jffs2reset"
 
 	$${HOST_SED} '/<link rel="shortcut icon" href="<%=media%>\/favicon.ico">/a         <link rel="stylesheet" href="<%=resource%>/easepi/easeicon.css?t=1749538073338">' \
-		"$${IPKG_INSTROOT}/usr/lib/lua/luci/view/themes/argon/header.htm" \
-		"$${IPKG_INSTROOT}/usr/lib/lua/luci/view/themes/argon_dark/header.htm" \
-		"$${IPKG_INSTROOT}/usr/lib/lua/luci/view/themes/argon_light/header.htm" \
-		"$${IPKG_INSTROOT}/usr/lib/lua/luci/view/themes/argon_dark_purple/header.htm" \
-		"$${IPKG_INSTROOT}/usr/lib/lua/luci/view/themes/argon_light_green/header.htm"
+		"$${IPKG_INSTROOT}/usr/lib/lua/luci/view/themes/argon/header.htm"
 
 	rm -f "$${IPKG_INSTROOT}/etc/uci-defaults/luci-argon-config"
 


### PR DESCRIPTION
Seven sed targets no longer exist. Checked against the official iStoreOS
24.10.8 x86/64 image (1041 packages, squashfs unpacked):

  usr/lib/lua/luci/controller/admin/system.lua
  usr/lib/lua/luci/model/cbi/hd_idle.lua
  usr/lib/lua/luci/model/cbi/admin_system/fstab/mount.lua
  usr/lib/lua/luci/view/themes/argon_{dark,light,dark_purple,light_green}/header.htm

luci-app-hd-idle and luci-mod-admin-full are installed, but their pages
moved to JS; the argon theme ships only the argon/ variant. Each sed fails
and the error is absorbed by the trailing `true`, so two customizations are
silently dropped: the hd-idle addremove flag and the fstab
/opt -> /overlay/upper/opt/docker mount path.

Kept: controller/admin/ota.lua (package/diy/luci-app-ota), bin/config_generate,
view/system/flash.js, themes/argon/header.htm, and both distfeeds files
(the opkg one is still reachable with USE_APK=n).

Verified on x86/64: the post-upgrade script in /lib/apk/db/scripts.tar.gz
no longer references the removed paths; all kept targets remain patched in
the rootfs.