### PR TITLE
istoreos-files: migrate apk distfeeds on upgrade

### DIFF
--- a/package/istoreos-files/files/etc/init.d/isos_upgrade
+++ b/package/istoreos-files/files/etc/init.d/isos_upgrade
@@ -95,6 +95,22 @@ upgrade_opkg_distfeeds() {
 	sed -E 's# https?://.*/releases/#'"$userrepo"'#g' /rom/etc/opkg/distfeeds.conf >> /etc/opkg/distfeeds.conf
 }
 
+upgrade_apk_distfeeds() {
+	local feeds=/etc/apk/repositories.d/distfeeds.list
+	local newrelease=$(grep -m1 '/base/packages\.adb$' /rom$feeds | grep -Eo '/releases/[^/]+/')
+	local oldrelease=$(grep -m1 '/base/packages\.adb$' $feeds | grep -Eo '/releases/[^/]+/')
+	[ -z "$newrelease" -o -z "$oldrelease" ] && return 0
+	[ "$newrelease" = "$oldrelease" ] && return 0
+
+	local romrepo="$(grep -m1 '/base/packages\.adb$' /rom$feeds | grep -Eo '^https?://.*/releases/')"
+	local userrepo="$(grep -m1 '/base/packages\.adb$' $feeds | grep -Eo '^https?://.*/releases/')"
+	if [ -z "$romrepo" -o -z "$userrepo" ]; then
+		cat /rom$feeds > $feeds
+		return 0
+	fi
+	sed -E 's#^https?://.*/releases/#'"$userrepo"'#g' /rom$feeds > $feeds
+}
+
 boot() {
 	[ -f /.recovery_mode ] && return 0
 
@@ -110,6 +126,9 @@ boot() {
 		}
 		is_overlayed /etc/opkg/distfeeds.conf && {
 			upgrade_opkg_distfeeds
+		}
+		is_overlayed /etc/apk/repositories.d/distfeeds.list && {
+			upgrade_apk_distfeeds
 		}
 	fi
 }


### PR DESCRIPTION
boot() only migrates /etc/opkg/distfeeds.conf. With CONFIG_USE_APK=y the
package feeds live in /etc/apk/repositories.d/distfeeds.list, so a
keep-settings upgrade leaves that file pinned to the previous release
version: the overlay copy shadows the new one from ROM and every feed URL
still points at the old /releases/<ver>/ path.

Add upgrade_apk_distfeeds(), a parallel of upgrade_opkg_distfeeds() for the
apk layout. Two format differences: entries are bare URLs with no
"src/gz <name> " prefix, so the base-feed anchor becomes
/base/packages.adb$ and the repository prefix is matched at start of line;
and the file carries no generated-file header.

Behaviour matches the opkg version: no-op when either side lacks a version
segment or when both are equal, full copy from ROM when a repository prefix
cannot be extracted, otherwise rewrite ROM entries onto the user's mirror.

Verified against the real 8-line distfeeds.list from a x86/64 build, six
cases: same version (untouched), version bump with a custom mirror (all 8
lines keep the mirror and take the new version), user file missing the base
entry (untouched), self-hosted repository without a /releases/ segment
(untouched, not overwritten with the official feeds), non-http scheme
(falls back to the ROM copy), and idempotency.