### PR TITLE
target/amlogic: filter apk distfeeds in postinst

### DIFF
--- a/target/linux/amlogic/meson/base-files.mk
+++ b/target/linux/amlogic/meson/base-files.mk
@@ -7,6 +7,7 @@ HOST_LN="$(subst ${STAGING_DIR_HOST},$${STAGING_DIR_HOST},$(LN))"
 
 [ -n "$${IPKG_INSTROOT}" ] && {
 	$${HOST_SED} '/targets\/amlogic\/meson/d' "$${IPKG_INSTROOT}/etc/opkg/distfeeds.conf"
+	$${HOST_SED} '/targets\/amlogic\/meson/d' "$${IPKG_INSTROOT}/etc/apk/repositories.d/distfeeds.list"
 }
 true
 


### PR DESCRIPTION
The base-files postinst drops the amlogic/meson target feed from
/etc/opkg/distfeeds.conf because that target is not published on
downloads.openwrt.org. With CONFIG_USE_APK=y the feeds live in
/etc/apk/repositories.d/distfeeds.list and no equivalent line exists, so
two unreachable entries stay in the image.

FeedSourcesAppendAPK emits %U/targets/%S/packages/packages.adb and
%U/targets/%S/kmods/<ver>/packages.adb, and %S expands to BOARD/SUBTARGET,
so the existing BRE pattern matches both formats unchanged.

The istoreos-files postinst keeps target feed entries, since they match
packages/packages.adb$ and kmods/.+/packages.adb$, so this deletion is
still required after that filter. Both are deletions, order between them
does not matter.

Verified by expanding a distfeeds.list for amlogic/meson and applying the
istoreos-files filter followed by this sed: ten entries reduce to six, none
target-scoped. Make parses the modified file with
PLATFORM_SUBDIR=target/linux/amlogic/meson; the -include is skipped under
DUMP=1, so a $(error) probe was used to confirm the path is reached.