### PR TITLE
istoreos-files: restore odhcpd PIO state across the piodir rename

### DIFF
--- a/package/istoreos-files/files/etc/init.d/odhcpd-state
+++ b/package/istoreos-files/files/etc/init.d/odhcpd-state
@@ -4,11 +4,79 @@ START=34
 STOP=86
 
 BACKUP_FILE="/etc/odhcpd-piodir-backup.tar.gz"
+LEGACY_BACKUP_FILE="/etc/odhcpd-piofolder-backup.tar.gz"
+
+pio_file_check() {
+	local file valid
+
+	file=$1
+	valid=0
+
+	json_init
+	json_load_file $file 2> /dev/null
+
+	if json_is_a slaac array; then
+		local keys len
+
+		json_select slaac
+		json_get_keys keys
+
+		len=$(echo $keys | wc -w)
+		if [ $len -gt 0 ]; then
+			valid=1
+		fi
+	fi
+
+	echo $valid
+}
+
+# Archives written before the piofolder -> piodir rename hold $piofolder/<name>,
+# while odhcpd now reads $piodir/odhcpd.pio.<name>. dhcp.odhcpd.piofolder is
+# already gone from uci by then, and /etc/uci-defaults/15_odhcpd runs from
+# /etc/init.d/boot at START=10, before this script at START=34, so its
+# pio_folder_migrate only ever sees a /tmp that the kernel just cleared. The old
+# layout is therefore recovered from the archive listing instead, reusing the
+# upstream validation and restricted to /tmp to match the shutdown side.
+pio_restore_legacy() {
+	local archive="$1"
+	local piodir="$2"
+	local legacy file
+
+	. /usr/share/libubox/jshn.sh
+
+	for legacy in $(tar -tzf "$archive" 2>/dev/null | \
+		sed -n 's#^/*\([^/][^/]*/[^/][^/]*\)/..*#/\1#p' | sort -u); do
+		[ "$legacy" = "$piodir" ] && continue
+		case "$legacy" in /tmp/*) ;; *) continue ;; esac
+		[ -d "$legacy" ] || continue
+
+		mkdir -p "$piodir"
+		for file in "$legacy"/*; do
+			[ -f "$file" ] || continue
+			if [ "$(pio_file_check $file)" = 1 ]; then
+				mv "$file" "$piodir/odhcpd.pio.${file##*/}"
+			else
+				rm -f "$file"
+			fi
+		done
+		rmdir "$legacy" 2>/dev/null
+	done
+}
 
 boot() {
-	[ -s "$BACKUP_FILE" ] || return 0
-	tar -xzf "$BACKUP_FILE" -C /
-	rm -f "$BACKUP_FILE"
+	local archive="$BACKUP_FILE"
+
+	# an archive written before the rename carries the old name and would
+	# otherwise be stranded in /etc
+	[ -s "$archive" ] || archive="$LEGACY_BACKUP_FILE"
+	[ -s "$archive" ] || return 0
+
+	local piodir=$(uci -q get dhcp.odhcpd.piodir)
+
+	tar -xzf "$archive" -C /
+	[ -n "$piodir" ] && pio_restore_legacy "$archive" "$piodir"
+
+	rm -f "$BACKUP_FILE" "$LEGACY_BACKUP_FILE"
 }
 
 shutdown() {


### PR DESCRIPTION
Rebased onto cf79cdd91f2. That commit renames the option and the archive, and two upgrade paths still drop the state left behind.

The archive name changed together with the option, so an archive written before the rename is called `odhcpd-piofolder-backup.tar.gz` and `boot()` no longer looks at it. It stays behind in `/etc` and the state is lost.

Its contents are in the old layout as well: `$piofolder/<name>`, while odhcpd now reads `$piodir/odhcpd.pio.<name>`. `/etc/uci-defaults/15_odhcpd` does convert that layout, but it runs from `/etc/init.d/boot` at `START=10`, ahead of this script at `START=34`, so its `pio_folder_migrate` only ever sees a `/tmp` the kernel just cleared, and `dhcp.odhcpd.piofolder` is already deleted by the time the archive is extracted.

`boot()` therefore falls back to the old archive name and recovers the old directory layout from the archive listing. Guards: directories equal to `piodir` are skipped so names are not prefixed twice, `/tmp` is enforced to match the invariant on the shutdown side, and the upstream `pio_file_check` validation is reused so entries `pio_folder_migrate` would have dropped are not restored.

Verified against the shipped file with only the jshn source path rewritten, 11 cases / 28 assertions: no archive, same-version round trip, pre-rename layout migration, invalid PIO discarded, repeated boot, unset piodir, non-/tmp piodir, out-of-tree archive member, missing directory, pre-rename archive name, and both archive names present at once.

The out-of-tree case asserts the file was extracted before asserting it was left alone, so the guard is what keeps it in place rather than a failed extraction. Each judgement in the function was separately inverted in the source to confirm the corresponding assertion turns red.