### PR TITLE
istoreos-files: drop the kmods feed from apk distfeeds

### DIFF
--- a/package/istoreos-files/Makefile
+++ b/package/istoreos-files/Makefile
@@ -57,7 +57,7 @@ HOST_LN="$(subst ${STAGING_DIR_HOST},$${STAGING_DIR_HOST},$(LN))"
 
 [ -n "$${IPKG_INSTROOT}" ] && {
 	$${HOST_SED} 's,^src/gz istoreos_,src/gz openwrt_,g' -e '/^src\/gz openwrt_\(core\|base\|kmods\|luci\|packages\|routing\|telephony\) /!d' "$${IPKG_INSTROOT}/etc/opkg/distfeeds.conf"
-	$${HOST_SED} '\#/\(base\|kmods/.*\|luci\|packages\|routing\|telephony\|video\)/packages\.adb$$#!d' "$${IPKG_INSTROOT}/etc/apk/repositories.d/distfeeds.list"
+	$${HOST_SED} '\#/\(base\|luci\|packages\|routing\|telephony\|video\)/packages\.adb$$#!d' "$${IPKG_INSTROOT}/etc/apk/repositories.d/distfeeds.list"
 
 	$${HOST_SED} 's/"192.168.1.1"/"192.168.100.1"/' \
 		"$${IPKG_INSTROOT}/usr/lib/lua/luci/controller/admin/system.lua" \


### PR DESCRIPTION
Rebased onto fc72e4feb47.

Every apk update reports the kmods repository as unreachable:

```
ERROR: wget: exited with error 8
WARNING: updating and opening .../targets/x86/64/kmods/6.12.94-1-a2749418e0b70648afb8d5d2bb701f22/packages.adb: unexpected end of file
```

The kmods repository path carries the kernel vermagic. 25.12.5 publishes exactly one for x86/64, `6.12.94-1-a7bc15f451f9652701ba04af9cfb0b95`, computed from the upstream kernel. A tree carrying kernel patches produces a different vermagic, so the generated URL cannot resolve against the configured release repository.

Until fc72e4feb47 this was masked: the pattern was written for ERE but run through `$(SED)`, so it matched no line and `!d` emptied the file. With the list populated the request is actually made.

Pinning `.vermagic` to the published value would not be safe. The kernel's own gates do not separate the two trees: both report `vermagic=6.12.94 SMP mod_unload`, `CONFIG_MODVERSIONS` and `CONFIG_MODULE_SIG` are off. Five patches under `target/linux/generic/hack-6.12` reorder `struct module`, `task_struct`, `net_namespace` and `net_device` in the exported headers, so an official kmod loaded against this kernel would read the wrong offsets. The mismatching hash is the last remaining gate.

Nothing is lost by removing the entry. kmods are kept out of `targets/<board>/<subtarget>/packages` upstream, so with the release repository configured those packages are not installable either way, and the entry only contributes a failing feed on every update.

A self-hosted repository is unaffected: a locally generated `targets/<board>/<subtarget>/packages/packages.adb` indexes the kmod packages alongside the rest, so no separate kmods entry is needed. Measured on x86/64: 1196 kmod entries in that index.

The remaining six feeds are release scoped and stay reachable. Measured after a rebuild: `distfeeds.list` goes from 8 lines to 7, with no kmods entry.
