### PR TITLE
base-files, istoreos-files: carry the overlay upgrade path over to apk

### DIFF
--- a/package/base-files/files/lib/upgrade/stage2
+++ b/package/base-files/files/lib/upgrade/stage2
@@ -151,6 +151,10 @@ istoreos_pre_upgrade() {
 			sync /ext_overlay
 		fi
 		echo "$running_ver" >/overlay/.upgrading
+		# Snapshot the world of the ROM being replaced. After the flash /rom
+		# holds the new one, and the difference against this snapshot is what
+		# the user installed on top.
+		[ -f /rom/etc/apk/world ] && cp /rom/etc/apk/world /overlay/.apk-world-rom
 		[ -f /overlay/upper/etc/uci-defaults/.upgrading ] || {
 			rm -f /overlay/upper/etc/uci-defaults/.upgrading
 			mkdir -p /overlay/upper/etc/uci-defaults

--- a/package/base-files/files/usr/sbin/mount_root
+++ b/package/base-files/files/usr/sbin/mount_root
@@ -185,8 +185,40 @@ clean_os_version_files()
 	cd - >/dev/null 2>&1
 }
 
+APK_PKGDIR=/lib/apk/packages
+APK_DB=/lib/apk/db/installed
+
+use_apk() {
+	[ -d $APK_PKGDIR ]
+}
+
+# $1 database, $2 package, $3 field prefix such as D: or V:. P: lines are
+# compared literally, since package names carry characters awk would read as
+# regular expression operators.
+apk_db_field() {
+	awk -v RS='' -v want="$2" -v f="$3" '
+		{
+			n = split($0, l, "\n")
+			hit = 0
+			for (i = 1; i <= n; i++)
+				if (substr(l[i], 1, 2) == "P:" && substr(l[i], 3) == want) { hit = 1; break }
+			if (!hit) next
+			for (i = 1; i <= n; i++)
+				if (substr(l[i], 1, 2) == f) { print substr(l[i], 3); exit }
+		}' "$1" 2>/dev/null
+}
+
 nonconf_files_of_pkg() {
 	local pkgname="$1"
+	if use_apk; then
+		if [ -s $APK_PKGDIR/${pkgname}.conffiles ]; then
+			grep -hvxFf $APK_PKGDIR/${pkgname}.conffiles \
+				$APK_PKGDIR/${pkgname}.list
+		else
+			cat $APK_PKGDIR/${pkgname}.list
+		fi
+		return
+	fi
 	if [ -s /usr/lib/opkg/info/${pkgname}.conffiles ]; then
 		grep -hvxFf /usr/lib/opkg/info/${pkgname}.conffiles \
 			/usr/lib/opkg/info/${pkgname}.list
@@ -200,6 +232,18 @@ clean_pkg_content() {
 	local pkgname="$2"
 	local line
 
+	if use_apk; then
+		# .list is to apk what .control is to opkg: it exists once per installed
+		# package and its name matches the P: field one to one.
+		if [ -f $APK_PKGDIR/${pkgname}.list ]; then
+			nonconf_files_of_pkg "${pkgname}" | grep -v '^/etc/uci-defaults/' | while read; do
+				line="$REPLY"
+				rm -f "$overlay/upper/${line}"
+			done
+			rm -f $overlay/upper$APK_PKGDIR/${pkgname}.*
+		fi
+		return
+	fi
 	if [ -f /usr/lib/opkg/info/${pkgname}.control ]; then
 		if [ -f /usr/lib/opkg/info/${pkgname}.list ]; then
 			nonconf_files_of_pkg "${pkgname}" | grep -v '^/etc/uci-defaults/' | while read; do
@@ -219,6 +263,21 @@ pkg_depends_rec() {
 	local deps
 
 	echo "${pkgname}" | grep -q '^kmod-' && return
+
+	if use_apk; then
+		[ -f $APK_PKGDIR/${pkgname}.list -a ! -f /tmp/reset_core_packages/${pkgname} ] || return
+		# D:kernel=6.12.94~<vermagic>-r1 kmod-libphy kmod-ptp
+		# A leading '!' marks a conflict, not a dependency. Drop the whole
+		# token: with a version bound such as !foo<1.0 the named package can
+		# legitimately be installed, so stripping only the '!' would pull it
+		# in as a dependency and reset a package the user upgraded.
+		deps=$(apk_db_field $APK_DB "${pkgname}" 'D:' | sed -e 's/![^ ]*//g' -e 's/[=<>~][^ ]*//g')
+		touch /tmp/reset_core_packages/${pkgname}
+		for dep in $deps ; do
+			pkg_depends_rec "$dep"
+		done
+		return
+	fi
 
 	if [ -f /usr/lib/opkg/info/${pkgname}.control -a ! -f /tmp/reset_core_packages/${pkgname} ]; then
 		deps=`grep '^Depends: ' /usr/lib/opkg/info/${pkgname}.control | sed -e 's/^Depends: //' -e 's/ ([^)]*)//g' -e 's/,/ /g'`
@@ -259,9 +318,53 @@ reset_core_packages()
 	done
 }
 
+# apk needs no equivalent of the opkg DUMMY_VERSION marker. There the version
+# lives in each package's .control and rebuild_opkg_status reads it back, so a
+# staled kmod has to stay behind as a marked file. Under apk the version lives
+# in the database record and isos_upgrade decides purely on whether the package
+# has a .list in the overlay upper, so removing the upper copies is the whole
+# signal: the ROM copy shows through again and the ROM record is taken, or the
+# package is gone from the merged view and its record is dropped. Re-entry is
+# covered for free, since a package with nothing left in upper is no longer a
+# candidate on the next boot. mount_root works on the raw upper directory
+# rather than through the overlay, so these removals leave no whiteout.
+clean_kmods_apk()
+{
+	local upper="$1/upper"
+	local compat pkg deps
+	[ -d "$upper$APK_PKGDIR" ] || return 0
+	[ -f "$upper$APK_DB" ] || return 0
+
+	compat=$(apk_db_field $APK_DB kernel 'V:')
+	[ -n "$compat" ] || return 0
+
+	( cd "$upper$APK_PKGDIR" && ls kmod-*.list 2>/dev/null | sed 's/\.list$//' ) | while read pkg; do
+		deps=$(apk_db_field "$upper$APK_DB" "$pkg" 'D:')
+		case " $deps " in
+			*" kernel=$compat "*) [ -f $APK_PKGDIR/${pkg}.list ] && echo "$pkg" ;;
+			*) echo "$pkg" ;;
+		esac
+	done > /tmp/del_kmods.txt
+
+	[ -s /tmp/del_kmods.txt ] || { rm -f /tmp/del_kmods.txt; return 0; }
+
+	echo "Clean kmods in $1: `cat /tmp/del_kmods.txt | xargs echo`" | dd bs=960 2>/dev/null
+
+	cat /tmp/del_kmods.txt | while read pkg; do
+		[ -f "$upper$APK_PKGDIR/${pkg}.list" ] && \
+			sed "s#^/#$upper/#" "$upper$APK_PKGDIR/${pkg}.list" | xargs -r rm -f
+		rm -f "$upper$APK_PKGDIR/${pkg}."*
+	done
+	rm -f /tmp/del_kmods.txt
+}
+
 clean_kmods()
 {
 	local DUMMY_VERSION=0.0.0-r1
+	if use_apk; then
+		clean_kmods_apk "$1"
+		return 0
+	fi
 	if [ -d "$1/upper/usr/lib/opkg/info" ]; then
 		local compat=`grep -m1 '^Version: ' /usr/lib/opkg/info/kernel.control | sed 's/^Version: //'`
 		if [ -n "$compat" ]; then

--- a/package/istoreos-files/files/etc/init.d/isos_upgrade
+++ b/package/istoreos-files/files/etc/init.d/isos_upgrade
@@ -62,6 +62,112 @@ clean_tmp_files() {
 	rm -rf /tmp/romopkgstatus
 }
 
+APK_DB=/lib/apk/db/installed
+APK_PKGDIR=/lib/apk/packages
+APK_WORLD=/etc/apk/world
+APK_WORLD_BASE=/overlay/.apk-world-rom
+
+# The apk database is a sequence of blank line separated records, so it splits
+# and rejoins byte for byte. Records are copied verbatim: a duplicated C: value
+# makes apk fault and truncate the database without reporting anything.
+split_apk_db() {
+	rm -rf $2
+	mkdir -p $2
+	awk -v out="$2" 'BEGIN{RS="";ORS=""}
+		{
+			name=""
+			n=split($0, line, "\n")
+			for (i = 1; i <= n; i++)
+				if (substr(line[i], 1, 2) == "P:") { name = substr(line[i], 3); break }
+			if (name != "") { f = out "/" name; printf "%s\n\n", $0 > f; close(f) }
+		}' $1
+}
+
+split_both_apk_db() {
+	split_apk_db $APK_DB /tmp/newapkdb &
+	split_apk_db /rom$APK_DB /tmp/romapkdb &
+	wait
+}
+
+ls_all_apk_pkgs() {
+	( cd $APK_PKGDIR ; find . -maxdepth 1 -name '*.list' | sed -E 's#\./(.*)\.list#\1#g' | grep -v '^kernel$' )
+}
+
+# world pins kernel to an exact vermagic and is refreshed from the new ROM, so a
+# stale kernel record would contradict it and apk would refuse every kmod. The
+# opkg path carries the same special case.
+rebuild_apk_db() {
+	local line
+	[ -f /tmp/romapkdb/kernel ] && cat /tmp/romapkdb/kernel
+	ls_all_apk_pkgs | while read; do
+		line="$REPLY"
+		if [ -f /overlay/upper$APK_PKGDIR/$line.list -o -f /ext_overlay/upper$APK_PKGDIR/$line.list ]; then
+			echo /tmp/newapkdb/$line
+		else
+			echo /tmp/romapkdb/$line
+		fi
+	done | xargs cat
+}
+
+# Keep the new ROM world, which carries fresh version pins, and re-add only the
+# packages the user installed on top of it. Those are emitted without a version
+# constraint: a pin inherited from the old image would name a version the new
+# repository no longer offers.
+rebuild_apk_world() {
+	local base=$APK_WORLD_BASE
+	[ -f /rom$APK_WORLD ] || return 1
+	[ -f $base ] || base=/rom$APK_WORLD
+	sed -E 's/[=<>~].*$//' $base | sort -u > /tmp/apkworldbase
+	{
+		cat /rom$APK_WORLD
+		sed -E 's/[=<>~].*$//' $APK_WORLD | grep -vxFf /tmp/apkworldbase
+	} | awk '!seen[$0]++'
+	rm -f /tmp/apkworldbase
+}
+
+clean_apk_tmp_files() {
+	rm -rf /tmp/newapkdb
+	rm -rf /tmp/romapkdb
+}
+
+# The database, the trigger list and the maintainer scripts are rewritten as a
+# set on every transaction, so a stale copy of any of them in the overlay hides
+# the whole set shipped by the new ROM.
+rebuild_apk_state() {
+	local ok=1
+
+	cp $APK_DB $APK_DB.isos-bak || return 1
+	cp $APK_WORLD $APK_WORLD.isos-bak || return 1
+
+	split_both_apk_db
+	rebuild_apk_db > $APK_DB.isos-new && [ -s $APK_DB.isos-new ] || ok=0
+	rebuild_apk_world > $APK_WORLD.isos-new && [ -s $APK_WORLD.isos-new ] || ok=0
+	clean_apk_tmp_files
+
+	if [ "$ok" = 1 ]; then
+		mv $APK_DB.isos-new $APK_DB
+		mv $APK_WORLD.isos-new $APK_WORLD
+		rm -f /overlay/upper/lib/apk/db/triggers /overlay/upper/lib/apk/db/scripts.tar.gz
+		rm -f /ext_overlay/upper/lib/apk/db/triggers /ext_overlay/upper/lib/apk/db/scripts.tar.gz
+	fi
+
+	rm -f $APK_DB.isos-new $APK_WORLD.isos-new
+
+	# apk fix -s reports an inconsistent installed set without needing the
+	# network, which matters because this runs at START=14, before network.
+	# apk info counts packages and stays quiet on exactly this fault.
+	if [ "$ok" = 1 ] && apk --no-network fix -s >/dev/null 2>&1; then
+		rm -f $APK_DB.isos-bak $APK_WORLD.isos-bak
+		rm -f $APK_WORLD_BASE
+		return 0
+	fi
+
+	mv $APK_DB.isos-bak $APK_DB
+	mv $APK_WORLD.isos-bak $APK_WORLD
+	logger -t isos_upgrade "apk database rebuild rejected by fix -s, restored"
+	return 1
+}
+
 clean_themes() {
 	local line
 	local name
@@ -104,6 +210,9 @@ boot() {
 			split_both_status
 			rebuild_opkg_status > /usr/lib/opkg/status
 			clean_tmp_files
+		}
+		is_overlayed /lib/apk/db/installed && {
+			rebuild_apk_state
 		}
 		is_overlayed /etc/config/luci && {
 			clean_themes


### PR DESCRIPTION
Under `CONFIG_USE_APK=y` a keep-settings sysupgrade leaves the overlay
shadowing the new ROM. Two places still key off opkg, and they are two
halves of one path, so neither is complete on its own.

`mount_root` runs first, at preinit. `nonconf_files_of_pkg`,
`clean_pkg_content`, `pkg_depends_rec` and `clean_kmods` all look under
`/usr/lib/opkg/info`, find nothing under apk, and the cleanup silently
does nothing. The overlay keeps shadowing the new ROM with the previous
luci, uhttpd, firewall4 and with kmods built for the previous vermagic.

`isos_upgrade` runs second, at boot. `rebuild_opkg_status` has no apk
counterpart, so `/lib/apk/db/installed` stays as the old image left it.
apk copies the whole database up into the overlay the first time a
package is installed, so after the flash the overlay copy shadows the new
ROM one and every record describes the previous image.

Landing only the `mount_root` half leaves database records pointing at
files that were just deleted. Landing only the `isos_upgrade` half leaves
the stale kmod files in place. Hence one change.

The per-package files map directly: `/lib/apk/packages/<pkg>.list` stands
in for `<pkg>.control` as the existence test, since it exists once per
installed package and its name matches the `P:` field one to one.
Dependencies come from the `D:` line, where a version constraint is
suffixed to the name rather than parenthesised, and a conflict is a
negated dependency rather than a separate field. The whole token is
dropped for a conflict: with a bound such as `!foo<1.0` the named package
can legitimately be installed, so stripping only the `!` would pull it in
as a dependency and reset a package the user upgraded. The shipped
database has 17 records carrying a conflict, `procd` among them, and
`procd` is in `list_core_packages`.

`clean_kmods` needs no equivalent of the `DUMMY_VERSION` marker. Under
opkg the version lives in each package's `.control` and
`rebuild_opkg_status` reads it back, so a staled kmod has to remain as a
marked file. Under apk the version lives in the database record and the
decision is whether the package still has a `.list` in the overlay upper,
so removing the upper copies carries the whole signal.

The opkg branches stay. A 24.10 to 25.12 overlay holds
`/usr/lib/opkg/info/*.control` and only that code can read it.

## Verification

Real machine, x86/64, keep-settings sysupgrade round trip, with one
package staged for each of the three kmod dispositions.

| | result |
|---|---|
| stale vermagic, not in ROM | removed, with both files its list owned |
| matching vermagic, also in ROM | overlay copy removed, ROM copy shows through, module still loads |
| matching vermagic, not in ROM | untouched |
| `apk --no-network fix -s` | 0 |
| packages / world / records | 1058 / 1058 / 1058 |
| duplicate `C:` values | 0 |
| world snapshot | consumed, so the main path ran rather than the fallback |
| `isos_upgrade` log lines | none, and it only logs on failure |

The vermagic did not change across that upgrade, so the stale case was
staged rather than produced by a kernel change.

Fixtures cover the branches: 24 assertions for the database rebuild and
38 for the overlay cleanup. Each assertion was checked to fail when the
judgement it covers is inverted in the source.
